### PR TITLE
Change sample assessment rules

### DIFF
--- a/scripts/populate_review_step.py
+++ b/scripts/populate_review_step.py
@@ -116,7 +116,7 @@ class PullRunElementInfo(PullInfo):
         fail_artifacts = [a for a in artifacts if a.udf.get('RE Review status') == 'fail']
 
         target_yield = float(sample.udf.get('Yield for Quoted Coverage (Gb)'))
-        good_re_yield = sum([float(a.udf.get('RE Yield Q30')) for a in pass_artifacts])
+        good_re_yield = sum([float(a.udf.get('RE Yield')) for a in pass_artifacts])
 
         # Just the right amount of good yield: take it all
         if target_yield < good_re_yield < target_yield * 2:
@@ -134,7 +134,7 @@ class PullRunElementInfo(PullInfo):
             pass_artifacts.sort(key=lambda x: x.udf.get('RE %Q30'), reverse=True)
             current_yield = 0
             for a in pass_artifacts:
-                current_yield += float(a.udf.get('RE Yield Q30'))
+                current_yield += float(a.udf.get('RE Yield'))
                 if current_yield < target_yield * 2:
                     a.udf['RE Useable'] = 'yes'
                     a.udf['RE Useable Comment'] = 'AR: Good yield'

--- a/scripts/populate_review_step.py
+++ b/scripts/populate_review_step.py
@@ -127,7 +127,7 @@ class PullRunElementInfo(PullInfo):
         # Artifacts that fail the review
         fail_artifacts = [a for a in artifacts if a.udf.get('RE Review status') == 'fail']
         # Artifacts that are new
-        new_artifacts = [a for a in pass_artifacts if a.udf.get('RE previous Useable') not in ['yes', 'no']]
+        new_artifacts = [a for a in artifacts if a.udf.get('RE previous Useable') not in ['yes', 'no']]
 
         # skip samples which have been delivered, mark any new REs as such, not changing older RE comments
         if self.delivered(sample.name):

--- a/scripts/populate_review_step.py
+++ b/scripts/populate_review_step.py
@@ -102,6 +102,7 @@ class PullRunElementInfo(PullInfo):
         ('RE Yield', 'clean_yield_in_gb'),
         ('RE Yield Q30', 'clean_yield_q30_in_gb'),
         ('RE %Q30', 'clean_pc_q30'),
+        ('RE Coverage', 'coverage.mean'),
         ('RE Estimated Duplicate Rate', 'lane_pc_optical_dups'),
         ('RE %Adapter', 'pc_adapter'),
         ('RE Review status', 'reviewed'),
@@ -158,8 +159,12 @@ class PullRunElementInfo(PullInfo):
         target_yield = float(sample.udf.get('Required Yield (Gb)'))
         good_re_yield = sum([float(a.udf.get('RE Yield')) for a in pass_artifacts])
 
+        # Increase target coverage by 5% to resolve borderline cases
+        target_coverage = 1.05 * sample.udf.get('Coverage (X)')
+        obtained_coverage = float(sum([a.udf.get('RE Coverage') for a in pass_artifacts]))
+
         # Just the right amount of good yield: take it all
-        if target_yield < good_re_yield < target_yield * 2:
+        if target_yield < good_re_yield < target_yield * 2 or target_coverage > obtained_coverage:
             for a in pass_artifacts:
                 a.udf['RE Useable'] = 'yes'
                 a.udf['RE Useable Comment'] = 'AR: Good yield'

--- a/scripts/populate_review_step.py
+++ b/scripts/populate_review_step.py
@@ -39,7 +39,7 @@ class StepPopulator(StepEPP, RestCommunicationEPP):
     def processed(self, sample_name):
         query_args = {'where': {'sample_id': sample_name}}
         sample = self.get_documents('samples', **query_args)[0]
-        processing_status = sample.get('aggregated').get('most_recent_proc').get('status')
+        processing_status = sample.get('aggregated', {}).get('most_recent_proc', {}).get('status')
         return processing_status == 'finished'
 
     def _run(self):

--- a/tests/test_populate_review_step.py
+++ b/tests/test_populate_review_step.py
@@ -13,7 +13,7 @@ class TestPopulator(TestEPP):
             self.epp_cls,
             'samples',
             new_callable=PropertyMock(
-                return_value=[NamedMock(real_name='a_sample', udf={'Yield for Quoted Coverage (Gb)': 95})]
+                return_value=[NamedMock(real_name='a_sample', udf={'Required Yield (Gb)': 95})]
             )
         )
         self.patched_lims = patch.object(self.epp_cls, 'lims', new_callable=PropertyMock)
@@ -72,7 +72,7 @@ class TestPullRunElementInfo(TestPopulator):
         def patch_output_artifact(output_artifacts):
             return patch.object(self.epp_cls, 'output_artifacts_per_sample', return_value=output_artifacts)
 
-        sample = NamedMock(real_name='a_sample', udf={'Yield for Quoted Coverage (Gb)': 95})
+        sample = NamedMock(real_name='a_sample', udf={'Required Yield (Gb)': 95})
         patched_output_artifacts_per_sample = patch_output_artifact([
             Mock(spec=Artifact, udf={'RE Yield': 115, 'RE %Q30': 75, 'RE Review status': 'pass'}),
             Mock(spec=Artifact, udf={'RE Yield': 95, 'RE %Q30': 85, 'RE Review status': 'pass'}),

--- a/tests/test_populate_review_step.py
+++ b/tests/test_populate_review_step.py
@@ -92,8 +92,8 @@ class TestPullRunElementInfo(TestPopulator):
         ])
         with patched_output_artifacts_per_sample as poa, self.patched_get_docs as pg:
             self.epp.assess_sample(sample)
-            assert poa.return_value[0].udf['RE Useable'] == 'yes'
-            assert poa.return_value[0].udf['RE Useable Comment'] == 'AR: Good yield'
+            assert poa.return_value[0].udf['RE Useable'] == 'no'
+            assert poa.return_value[0].udf['RE Useable Comment'] == 'AR: Too much good yield'
 
             assert poa.return_value[1].udf['RE Useable'] == 'yes'
             assert poa.return_value[1].udf['RE Useable Comment'] == 'AR: Good yield'
@@ -109,6 +109,7 @@ class TestPullRunElementInfo(TestPopulator):
             self.epp.assess_sample(sample)
             assert poa.return_value[0].udf['RE Useable'] == 'yes'
             assert poa.return_value[0].udf['RE Useable Comment'] == 'AR: Good yield'
+
 
             assert poa.return_value[1].udf['RE Useable'] == 'no'
             assert poa.return_value[1].udf['RE Useable Comment'] == 'AR: Failed and not needed'

--- a/tests/test_populate_review_step.py
+++ b/tests/test_populate_review_step.py
@@ -114,6 +114,30 @@ class TestPullRunElementInfo(TestPopulator):
             assert poa.return_value[1].udf['RE Useable'] == 'no'
             assert poa.return_value[1].udf['RE Useable Comment'] == 'AR: Failed and not needed'
 
+        patched_output_artifacts_per_sample = patch_output_artifact([
+            Mock(spec=Artifact, udf={'RE Yield': 115, 'RE %Q30': 85, 'RE Review status': 'pass', 'RE Coverage': 35.2}),
+            Mock(spec=Artifact, udf={'RE Yield': 15, 'RE %Q30': 70, 'RE Review status': 'fail', 'RE Coverage': 33.6}),
+        ])
+
+        delivered = 'scripts.populate_review_step.PullRunElementInfo.delivered'
+        processed = 'scripts.populate_review_step.PullRunElementInfo.processed'
+        patched_delivered = patch(delivered, return_value=True)
+        pathed_processed = patch(processed, return_value=True)
+
+        with patched_output_artifacts_per_sample as poa, self.patched_get_docs as pg, patched_delivered:
+            self.epp.assess_sample(sample)
+            assert poa.return_value[0].udf['RE Useable'] == 'no'
+            assert poa.return_value[0].udf['RE Useable Comment'] == 'AR: Delivered'
+            assert poa.return_value[1].udf['RE Useable'] == 'no'
+            assert poa.return_value[1].udf['RE Useable Comment'] == 'AR: Delivered'
+
+        with patched_output_artifacts_per_sample as poa, self.patched_get_docs as pg, pathed_processed:
+            self.epp.assess_sample(sample)
+            assert poa.return_value[0].udf['RE Useable'] == 'no'
+            assert poa.return_value[0].udf['RE Useable Comment'] == 'AR: Sample already processed'
+            assert poa.return_value[1].udf['RE Useable'] == 'no'
+            assert poa.return_value[1].udf['RE Useable Comment'] == 'AR: Sample already processed'
+
     def test_field_from_entity(self):
         entity = {'this': {'that': 'other'}}
         assert self.epp.field_from_entity(entity, 'this.that') == 'other'

--- a/tests/test_populate_review_step.py
+++ b/tests/test_populate_review_step.py
@@ -40,7 +40,6 @@ class TestPullRunElementInfo(TestPopulator):
         'reviewed': 'pass',
         'review_comments': 'alright',
         'review_date': '12_02_2107_12:43:24',
-        'aggregated': {'most_recent_proc': {'status': 'finished'}}
     }
     expected_udfs = {
         'RE Id': 'id',

--- a/tests/test_populate_review_step.py
+++ b/tests/test_populate_review_step.py
@@ -74,9 +74,9 @@ class TestPullRunElementInfo(TestPopulator):
 
         sample = NamedMock(real_name='a_sample', udf={'Yield for Quoted Coverage (Gb)': 95})
         patched_output_artifacts_per_sample = patch_output_artifact([
-            Mock(spec=Artifact, udf={'RE Yield Q30': 115, 'RE %Q30': 75, 'RE Review status': 'pass'}),
-            Mock(spec=Artifact, udf={'RE Yield Q30': 95, 'RE %Q30': 85, 'RE Review status': 'pass'}),
-            Mock(spec=Artifact, udf={'RE Yield Q30': 15, 'RE %Q30': 70, 'RE Review status': 'fail'}),
+            Mock(spec=Artifact, udf={'RE Yield': 115, 'RE %Q30': 75, 'RE Review status': 'pass'}),
+            Mock(spec=Artifact, udf={'RE Yield': 95, 'RE %Q30': 85, 'RE Review status': 'pass'}),
+            Mock(spec=Artifact, udf={'RE Yield': 15, 'RE %Q30': 70, 'RE Review status': 'fail'}),
         ])
         with patched_output_artifacts_per_sample as poa:
             self.epp.assess_sample(sample)
@@ -90,8 +90,8 @@ class TestPullRunElementInfo(TestPopulator):
             assert poa.return_value[2].udf['RE Useable Comment'] == 'AR: Failed and not needed'
 
         patched_output_artifacts_per_sample = patch_output_artifact([
-            Mock(spec=Artifact, udf={'RE Yield Q30': 115, 'RE %Q30': 85, 'RE Review status': 'pass'}),
-            Mock(spec=Artifact, udf={'RE Yield Q30': 15, 'RE %Q30': 70, 'RE Review status': 'fail'}),
+            Mock(spec=Artifact, udf={'RE Yield': 115, 'RE %Q30': 85, 'RE Review status': 'pass'}),
+            Mock(spec=Artifact, udf={'RE Yield': 15, 'RE %Q30': 70, 'RE Review status': 'fail'}),
         ])
         with patched_output_artifacts_per_sample as poa:
             self.epp.assess_sample(sample)

--- a/tests/test_populate_review_step.py
+++ b/tests/test_populate_review_step.py
@@ -39,7 +39,8 @@ class TestPullRunElementInfo(TestPopulator):
         'pc_adapter': 1.2,
         'reviewed': 'pass',
         'review_comments': 'alright',
-        'review_date': '12_02_2107_12:43:24'
+        'review_date': '12_02_2107_12:43:24',
+        'aggregated': {'most_recent_proc': {'status': 'finished'}}
     }
     expected_udfs = {
         'RE Id': 'id',
@@ -59,8 +60,10 @@ class TestPullRunElementInfo(TestPopulator):
                 self.patched_output_artifacts_per_sample as poa:
             self.epp.run()
 
-            assert pg.call_count == 2
-            assert pg.call_args_list == [call('aggregate/run_elements', match={'sample_id': 'a_sample'}), call('samples', where={'sample_id': 'a_sample'})]
+            assert pg.call_count == 3
+            assert pg.call_args_list == [call('aggregate/run_elements', match={'sample_id': 'a_sample'}),
+                                         call('samples', where={'sample_id': 'a_sample'}),
+                                         call('samples', where={'sample_id': 'a_sample'})]
 
             # Check that the udfs have been added
             assert dict(poa.return_value[0].udf) == self.expected_udfs


### PR DESCRIPTION
Change the criteria for reviewing run elements so that it is more accurate. Previously using Yield Q30 which caused some samples to be inaccurately reviewed automatically
fixes #40 