### PR TITLE
Quant studio

### DIFF
--- a/scripts/next_step_assignment_quantstudio_data_import.py
+++ b/scripts/next_step_assignment_quantstudio_data_import.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+from EPPs.common import step_argparser, StepEPP
+from EPPs.config import load_config
+from pyclarity_lims.entities import Protocol
+
+
+class AssignNextStepQuantStudio(StepEPP):
+    """
+    This script assigns the next step for all samples in the step as either "review","complete" or "nextstep"
+    for next step it assumes the next step wanted is the next step in the protocol i.e. doesn't skip one or more steps
+    in the configuration assumes that all artifacts should have the same next step
+    """
+
+    def __init__(self, step_uri, username, password, log_file=None, review=False, remove=False):
+        super().__init__(step_uri, username, password, log_file)
+        self.review = review
+        self.remove = remove
+
+    def _run(self):
+
+        # obtain the actions of the step then creates a StepActions entity for the current step
+        actions = self.process.step.actions
+
+        # obtain the next actions in the step then creates a list of dict for next_actions for the step for all artifacts
+        next_actions = actions.next_actions
+        print(next_actions)
+        #check to see if the number of SNP calls in the  parsed data is above or below the threshold and assign next
+        #step to either manager review or complete and assign QuantStudio QC flag for submitted sample
+        for next_action in next_actions:
+            art=next_action['artifact']
+            sample = art.samples[0]
+            if sample.udf.get("Number of Calls (Best Run)") < self.process.udf.get("Minimum Number of Calls"):
+                sample.udf["QuantStudio QC"] ="FAIL"
+                sample.put()
+                next_action['action'] = 'review'
+            elif sample.udf.get("Number of Calls (Best Run)") >= self.process.udf.get("Minimum Number of Calls"):
+                sample.udf["QuantStudio QC"] = "PASS"
+                sample.put()
+                next_action['action'] = 'complete'
+
+        actions.put()
+
+
+def main():
+    # Get the default command line options
+    p = step_argparser()
+
+    # Parse command line options
+    args = p.parse_args()
+
+
+    # Setup the EPP
+    action = AssignNextStepQuantStudio(
+        args.step_uri, args.username, args.password, args.log_file
+    )
+
+    # Run the EPP
+    action.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/next_step_assignment_quantstudio_data_import.py
+++ b/scripts/next_step_assignment_quantstudio_data_import.py
@@ -4,9 +4,8 @@ from EPPs.common import step_argparser, StepEPP
 
 class AssignNextStepQuantStudio(StepEPP):
     """
-    This script assigns the next step for all samples in the step as either "review","complete" or "nextstep"
-    for next step it assumes the next step wanted is the next step in the protocol i.e. doesn't skip one or more steps
-    in the configuration assumes that all artifacts should have the same next step
+    This script assigns the next step for samples in the QuantStudio Data Import step. It assigns the next step as
+    either complete or review depending on whether the number of SNP calls exceeds the minimum number of calls.
     """
 
     def _run(self):

--- a/scripts/next_step_assignment_quantstudio_data_import.py
+++ b/scripts/next_step_assignment_quantstudio_data_import.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 from EPPs.common import step_argparser, StepEPP
-from EPPs.config import load_config
-from pyclarity_lims.entities import Protocol
 
 
 class AssignNextStepQuantStudio(StepEPP):
@@ -11,11 +9,6 @@ class AssignNextStepQuantStudio(StepEPP):
     in the configuration assumes that all artifacts should have the same next step
     """
 
-    def __init__(self, step_uri, username, password, log_file=None, review=False, remove=False):
-        super().__init__(step_uri, username, password, log_file)
-        self.review = review
-        self.remove = remove
-
     def _run(self):
 
         # obtain the actions of the step then creates a StepActions entity for the current step
@@ -23,14 +16,14 @@ class AssignNextStepQuantStudio(StepEPP):
 
         # obtain the next actions in the step then creates a list of dict for next_actions for the step for all artifacts
         next_actions = actions.next_actions
-        print(next_actions)
-        #check to see if the number of SNP calls in the  parsed data is above or below the threshold and assign next
-        #step to either manager review or complete and assign QuantStudio QC flag for submitted sample
+
+        # check to see if the number of SNP calls in the  parsed data is above or below the threshold and assign next
+        # step to either manager review or complete and assign QuantStudio QC flag for submitted sample
         for next_action in next_actions:
-            art=next_action['artifact']
+            art = next_action['artifact']
             sample = art.samples[0]
             if sample.udf.get("Number of Calls (Best Run)") < self.process.udf.get("Minimum Number of Calls"):
-                sample.udf["QuantStudio QC"] ="FAIL"
+                sample.udf["QuantStudio QC"] = "FAIL"
                 sample.put()
                 next_action['action'] = 'review'
             elif sample.udf.get("Number of Calls (Best Run)") >= self.process.udf.get("Minimum Number of Calls"):
@@ -47,7 +40,6 @@ def main():
 
     # Parse command line options
     args = p.parse_args()
-
 
     # Setup the EPP
     action = AssignNextStepQuantStudio(

--- a/tests/test_next_step_assignment_quantstudio_data_import.py
+++ b/tests/test_next_step_assignment_quantstudio_data_import.py
@@ -1,0 +1,48 @@
+from scripts.next_step_assignment_quantstudio_data_import import AssignNextStepQuantStudio
+from tests.test_common import TestEPP, fake_artifact
+from unittest.mock import Mock, patch, PropertyMock
+
+
+def fake_next_actions(unique=False, resolve=False):
+    """Return a list of mocked artifacts which contain samples which contain artifacts ... Simple!"""
+    return [
+        {'artifact':Mock(samples=[Mock(udf={'Number of Calls (Best Run)': 27})])},
+        {'artifact':Mock(samples=[Mock(udf={'Number of Calls (Best Run)': 15})])}
+    ]
+
+class TestAssignNextStep(TestEPP):
+    def setUp(self):
+        self.patched_process = patch.object(
+            AssignNextStepQuantStudio,
+            'process',
+            new_callable=PropertyMock(
+                return_value=Mock(
+                    udf={
+                        'Minimum Number of Calls': 25,
+                    },
+                    step=Mock(
+                        actions=Mock(
+                            next_actions=fake_next_actions()
+                        )
+                    )
+                )
+            )
+        )
+        print(self.patched_process)
+        self.epp = AssignNextStepQuantStudio(
+            'http://server:8080/a_step_uri',
+            'a_user',
+            'a_password',
+            self.log_file
+        )
+
+    def test_assign_next_step_quant_studio(self):
+        with self.patched_process:
+            self.epp._run()
+
+            assert self.epp.process.step.actions.next_actions[0]['action'] == 'complete'
+            assert self.epp.process.step.actions.next_actions[0]['artifact'].samples[0].udf.get('QuantStudio QC')=="PASS"
+            assert self.epp.process.step.actions.next_actions[1]['action'] == 'review'
+            assert self.epp.process.step.actions.next_actions[1]['artifact'].samples[0].udf.get(
+                'QuantStudio QC') == "FAIL"
+            assert self.epp.process.step.actions.put.call_count == 1

--- a/tests/test_next_step_assignment_quantstudio_data_import.py
+++ b/tests/test_next_step_assignment_quantstudio_data_import.py
@@ -6,9 +6,10 @@ from unittest.mock import Mock, patch, PropertyMock
 def fake_next_actions(unique=False, resolve=False):
     """Return a list of mocked artifacts which contain samples which contain artifacts ... Simple!"""
     return [
-        {'artifact':Mock(samples=[Mock(udf={'Number of Calls (Best Run)': 27})])},
-        {'artifact':Mock(samples=[Mock(udf={'Number of Calls (Best Run)': 15})])}
+        {'artifact': Mock(samples=[Mock(udf={'Number of Calls (Best Run)': 27})])},
+        {'artifact': Mock(samples=[Mock(udf={'Number of Calls (Best Run)': 15})])}
     ]
+
 
 class TestAssignNextStep(TestEPP):
     def setUp(self):
@@ -28,7 +29,7 @@ class TestAssignNextStep(TestEPP):
                 )
             )
         )
-        print(self.patched_process)
+
         self.epp = AssignNextStepQuantStudio(
             'http://server:8080/a_step_uri',
             'a_user',
@@ -41,7 +42,8 @@ class TestAssignNextStep(TestEPP):
             self.epp._run()
 
             assert self.epp.process.step.actions.next_actions[0]['action'] == 'complete'
-            assert self.epp.process.step.actions.next_actions[0]['artifact'].samples[0].udf.get('QuantStudio QC')=="PASS"
+            assert self.epp.process.step.actions.next_actions[0]['artifact'].samples[0].udf.get(
+                'QuantStudio QC') == "PASS"
             assert self.epp.process.step.actions.next_actions[1]['action'] == 'review'
             assert self.epp.process.step.actions.next_actions[1]['artifact'].samples[0].udf.get(
                 'QuantStudio QC') == "FAIL"


### PR DESCRIPTION
Repeat pull request for:
New script for assigning the next step to artifacts in the QuantStudio Data Import step. Next step is either complete if the Number of Calls (for SNPs) is above the minimum or manager review if the Number of Calls is below the minimum. It also updates a QC UDF to assist the manager in reviewing the step.