### PR TITLE
Fix failed overwriting

### DIFF
--- a/scripts/convert_and_dispatch_genotypes.py
+++ b/scripts/convert_and_dispatch_genotypes.py
@@ -241,8 +241,8 @@ class UploadVcfToSamples(StepEPP):
             # This is the first genotyping results
             lims_sample.udf[submitted_genotype_udf_number_call] = nb_call
             lims_sample.udf[genotype_udf_file_id] = lims_file.id
-        elif lims_sample.udf.get(submitted_genotype_udf_number_call) and \
-                nb_call > lims_sample.udf.get(submitted_genotype_udf_number_call):
+        elif submitted_genotype_udf_number_call in lims_sample.udf and \
+                nb_call > (lims_sample.udf.get(submitted_genotype_udf_number_call) or 0):
             # This genotyping is better than before
             lims_sample.udf[submitted_genotype_udf_number_call] = nb_call
             lims_sample.udf[genotype_udf_file_id] = lims_file.id

--- a/tests/test_convert_and_dispatch_genotypes.py
+++ b/tests/test_convert_and_dispatch_genotypes.py
@@ -170,7 +170,7 @@ class TestUploadVcfToSamples(TestEPP):
             }
             self.lims_sample2.udf = {
                 'QuantStudio Data Import Completed #': 1,
-                'Number of Calls (Best Run)': 12,
+                'Number of Calls (Best Run)': 0,
                 'Genotyping results file id': 'old_file_id'
             }
             mlims.upload_new_file.return_value = Mock(id='file_id')


### PR DESCRIPTION
Ensure that when best runs is 0, it still compares it with the new genotype results.
fixes #61 