### PR TITLE
Remove sample if not going through seqlab

### DIFF
--- a/scripts/assign_workflow_preseqlab.py
+++ b/scripts/assign_workflow_preseqlab.py
@@ -1,15 +1,18 @@
 #!/usr/bin/env python
+from pyclarity_lims.entities import Step
+
 from EPPs.common import StepEPP, get_workflow_stage, find_newest_artifact_originating_from
 
 
 class AssignWorkflowPreSeqLab(StepEPP):
     def _run(self):
-        artifacts_to_route = set()
+        artifacts_to_route_to_seq_lab = set()
+        artifacts_to_route_to_remove = set()
         for art in self.artifacts:
             sample = art.samples[0]
             if sample.udf.get("Proceed To SeqLab") and not sample.udf.get("2D Barcode"):
                 # checks to see if sample is in plate or fluidX tube
-                artifacts_to_route.add(sample.artifact)
+                artifacts_to_route_to_seq_lab.add(sample.artifact)
 
             elif sample.udf.get("Proceed To SeqLab") and sample.udf.get("2D Barcode"):
                 artifact = find_newest_artifact_originating_from(
@@ -17,12 +20,36 @@ class AssignWorkflowPreSeqLab(StepEPP):
                     process_type="FluidX Transfer From Rack Into Plate EG 1.0 ST",
                     sample_name=sample.name
                 )
-                artifacts_to_route.add(artifact)
+                artifacts_to_route_to_seq_lab.add(artifact)
 
-        if artifacts_to_route:
+            else:
+                artifacts_to_route_to_remove.add(sample.artifact)
+
+        if artifacts_to_route_to_seq_lab:
             # Only route artifacts if there are any
             stage = get_workflow_stage(self.lims, "PreSeqLab EG 6.0", "Sequencing Plate Preparation EG 2.0")
-            self.lims.route_artifacts(list(artifacts_to_route), stage_uri=stage.uri)
+            self.lims.route_artifacts(list(artifacts_to_route_to_seq_lab), stage_uri=stage.uri)
+
+        if artifacts_to_route_to_remove:
+            stage = get_workflow_stage(self.lims, "Remove From Processing EG 1.0 WF", "Remove From Processing EG 1.0 ST")
+            self.lims.route_artifacts(list(artifacts_to_route_to_remove), stage_uri=stage.uri)
+
+            # Create new step with the routed artifacts
+            s = Step.create(self.lims, protocol_step=stage.step, inputs=artifacts_to_route_to_remove,
+                            container_type_name='Tube')
+
+            s.details.udf['Reason for removal from processing:'] = 'Failed QC. See step id %s' % self.process.id
+            s.details.put()
+
+            # Move from "Record detail" window to the "Next Step"
+            s.advance()
+
+            for next_action in s.actions.next_actions:
+                next_action['action'] = 'complete'
+            s.actions.put()
+
+            # Complete the step
+            s.advance()
 
 
 if __name__ == "__main__":

--- a/scripts/assign_workflow_preseqlab.py
+++ b/scripts/assign_workflow_preseqlab.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import platform
+
 from pyclarity_lims.entities import Step
 
 from EPPs.common import StepEPP, get_workflow_stage, find_newest_artifact_originating_from
@@ -38,7 +40,8 @@ class AssignWorkflowPreSeqLab(StepEPP):
             s = Step.create(self.lims, protocol_step=stage.step, inputs=artifacts_to_route_to_remove,
                             container_type_name='Tube')
 
-            s.details.udf['Reason for removal from processing:'] = 'Failed QC. See step id %s' % self.process.id
+            url = 'https://%s/clarity/work-complete/%s' % (platform.node(), self.process.id.split('-')[1])
+            s.details.udf['Reason for removal from processing:'] = 'Failed QC. See step %s' % url
             s.details.put()
 
             # Move from "Record detail" window to the "Next Step"

--- a/tests/test_assign_to_workflow_preseqlab.py
+++ b/tests/test_assign_to_workflow_preseqlab.py
@@ -7,7 +7,8 @@ def fake_all_inputs(unique=False, resolve=False):
     """Return a list of mocked artifacts which contain samples which contain artifacts ... Simple!"""
     return (
         Mock(samples=[Mock(artifact=fake_artifact('a1'), id='s1', udf={'Proceed To SeqLab': True})]),
-        Mock(samples=[Mock(artifact=fake_artifact('a2'), id='s2', udf={'Proceed To SeqLab': True, '2D Barcode': 'fluidX1'})])
+        Mock(samples=[Mock(artifact=fake_artifact('a2'), id='s2', udf={'Proceed To SeqLab': True, '2D Barcode': 'fluidX1'})]),
+        Mock(samples=[Mock(artifact=fake_artifact('a3'), id='s3', udf={'Proceed To SeqLab': False})])
     )
 
 
@@ -18,20 +19,46 @@ class TestAssignWorkflowPreSeqLab(TestEPP):
             'process',
             new_callable=PropertyMock(return_value=Mock(all_inputs=fake_all_inputs))
         )
+        self.workflow_stage = Mock(uri='a_uri')
         self.patched_get_workflow_stage = patch(
             'scripts.assign_workflow_preseqlab.get_workflow_stage',
-            return_value=Mock(uri='a_uri')
+            return_value=self.workflow_stage
         )
         self.patch_find_art = patch(
             'scripts.assign_workflow_preseqlab.find_newest_artifact_originating_from',
             return_value=Mock(id='fx2')
         )
+        self.mocked_step = Mock(details=Mock(udf={}), actions=Mock(next_actions=[{}]))
+        self.patch_Step_create = patch('scripts.assign_workflow_preseqlab.Step.create', return_value=self.mocked_step)
         self.epp = AssignWorkflowPreSeqLab(self.default_argv)
 
     def test_assign(self):
-        with self.patched_get_workflow_stage as pws, self.patched_lims, self.patched_process, self.patch_find_art:
+        with self.patched_get_workflow_stage as pws, self.patched_lims, self.patched_process, self.patch_find_art, \
+             self.patch_Step_create as psc:
             self.epp._run()
 
-            pws.assert_called_with(self.epp.lims, 'PreSeqLab EG 6.0', 'Sequencing Plate Preparation EG 2.0')
-            assert sorted([a.id for a in self.epp.lims.route_artifacts.call_args[0][0]]) == ['a1', 'fx2']
-            assert self.epp.lims.route_artifacts.call_args[1] == {'stage_uri': 'a_uri'}
+            pws.assert_called_any(self.epp.lims, 'PreSeqLab EG 6.0', 'Sequencing Plate Preparation EG 2.0')
+            first_call = self.epp.lims.route_artifacts.call_args_list[0]
+            assert sorted([a.id for a in first_call[0][0]]) == ['a1', 'fx2']
+            assert first_call[1] == {'stage_uri': 'a_uri'}
+
+            pws.assert_called_any(self.epp.lims, "Remove From Processing EG 1.0 WF", "Remove From Processing EG 1.0 ST")
+            second_call = self.epp.lims.route_artifacts.call_args_list[1]
+            assert sorted([a.id for a in second_call[0][0]]) == ['a3']
+            assert second_call[1] == {'stage_uri': 'a_uri'}
+            # Test the Step creation
+            psc.assert_called_with(
+                self.epp.lims,
+                inputs=set([self.epp.artifacts[2].samples[0].artifact]),
+                protocol_step=self.workflow_stage.step,
+                container_type_name='Tube'
+            )
+            # Test udf in details
+            assert 'Reason for removal from processing:' in self.mocked_step.details.udf
+            self.mocked_step.details.put.assert_called_with()
+            # Test next actions has been set.
+            assert self.mocked_step.actions.next_actions == [{'action': 'complete'}]
+            self.mocked_step.actions.put.assert_called_with()
+
+            # Test advance has been called.
+            assert self.mocked_step.advance.call_count == 2

--- a/tests/test_assign_to_workflow_preseqlab.py
+++ b/tests/test_assign_to_workflow_preseqlab.py
@@ -17,7 +17,7 @@ class TestAssignWorkflowPreSeqLab(TestEPP):
         self.patched_process = patch.object(
             AssignWorkflowPreSeqLab,
             'process',
-            new_callable=PropertyMock(return_value=Mock(all_inputs=fake_all_inputs))
+            new_callable=PropertyMock(return_value=Mock(id='24-1234', all_inputs=fake_all_inputs))
         )
         self.workflow_stage = Mock(uri='a_uri')
         self.patched_get_workflow_stage = patch(

--- a/tests/test_assign_to_workflow_preseqlab.py
+++ b/tests/test_assign_to_workflow_preseqlab.py
@@ -37,12 +37,12 @@ class TestAssignWorkflowPreSeqLab(TestEPP):
              self.patch_Step_create as psc:
             self.epp._run()
 
-            pws.assert_called_any(self.epp.lims, 'PreSeqLab EG 6.0', 'Sequencing Plate Preparation EG 2.0')
+            pws.assert_any_call(self.epp.lims, 'PreSeqLab EG 6.0', 'Sequencing Plate Preparation EG 2.0')
             first_call = self.epp.lims.route_artifacts.call_args_list[0]
             assert sorted([a.id for a in first_call[0][0]]) == ['a1', 'fx2']
             assert first_call[1] == {'stage_uri': 'a_uri'}
 
-            pws.assert_called_any(self.epp.lims, "Remove From Processing EG 1.0 WF", "Remove From Processing EG 1.0 ST")
+            pws.assert_any_call(self.epp.lims, "Remove From Processing EG 1.0 WF", "Remove From Processing EG 1.0 ST")
             second_call = self.epp.lims.route_artifacts.call_args_list[1]
             assert sorted([a.id for a in second_call[0][0]]) == ['a3']
             assert second_call[1] == {'stage_uri': 'a_uri'}


### PR DESCRIPTION
Change `assign_workflow_preseqlab.py` to push samples through the remove workflow when the UDF `Proceed To SeqLab` is not set.
fixes #70 
