### PR TITLE
Assign samples using config file to set workflow and step

### DIFF
--- a/EPPs/etc/example_clarity_script.yml
+++ b/EPPs/etc/example_clarity_script.yml
@@ -57,3 +57,20 @@ rest_api:
   url: localhost
   username: user
   password: password
+
+workflow_stage:
+  kapa:
+    - KAPA Non-Pooling Sample Prep EG 1.0 WF
+    - Sequencing Plate Picogreen EG 1.0 ST
+  pcr-free:
+    - TruSeq PCR-Free DNA Sample Prep
+    - Visual QC
+  nano:
+    - TruSeq Nano DNA Sample Prep
+    - Visual QC
+  quantstudio:
+    - QuantStudio EG1.0
+    - QuantStudio Plate Preparation EG1.0
+
+process_type:
+  fluidx_transfer: FluidX Transfer From Rack Into Plate EG 1.0 ST

--- a/EPPs/etc/example_clarity_script.yml
+++ b/EPPs/etc/example_clarity_script.yml
@@ -60,17 +60,21 @@ rest_api:
 
 workflow_stage:
   kapa:
-    - KAPA Non-Pooling Sample Prep EG 1.0 WF
-    - Sequencing Plate Picogreen EG 1.0 ST
+    start:
+      - KAPA Non-Pooling Sample Prep EG 1.0 WF
+      - Sequencing Plate Picogreen EG 1.0 ST
   pcr-free:
-    - TruSeq PCR-Free DNA Sample Prep
-    - Visual QC
+    start:
+      - TruSeq PCR-Free DNA Sample Prep
+      - Visual QC
   nano:
-    - TruSeq Nano DNA Sample Prep
-    - Visual QC
+    start:
+      - TruSeq Nano DNA Sample Prep
+      - Visual QC
   quantstudio:
-    - QuantStudio EG1.0
-    - QuantStudio Plate Preparation EG1.0
+    start:
+      - QuantStudio EG1.0
+      - QuantStudio Plate Preparation EG1.0
 
 process_type:
   fluidx_transfer: FluidX Transfer From Rack Into Plate EG 1.0 ST

--- a/scripts/assign_workflow_seqlab_quantstudio.py
+++ b/scripts/assign_workflow_seqlab_quantstudio.py
@@ -51,7 +51,7 @@ class AssignWorkflowSeqLabQuantStudio(StepEPP):
             self.lims.route_artifacts(list(artifacts_to_route_pcr_free), stage_uri=stage.uri)
 
         if artifacts_to_route_nano:
-            stage_wf_st= cfg.query('workflow_stage', 'nano')
+            stage_wf_st = cfg.query('workflow_stage', 'nano')
             stage = get_workflow_stage(self.lims, stage_wf_st[0], stage_wf_st[1])
             self.lims.route_artifacts(list(artifacts_to_route_nano), stage_uri=stage.uri)
 

--- a/scripts/assign_workflow_seqlab_quantstudio.py
+++ b/scripts/assign_workflow_seqlab_quantstudio.py
@@ -5,7 +5,6 @@ from EPPs.common import StepEPP, get_workflow_stage, find_newest_artifact_origin
 
 
 class AssignWorkflowSeqLabQuantStudio(StepEPP):
-    _use_load_config = True  # prevent the loading of the config file
     """
     Assigns plates of submitted samples or FluidX derived artifacts to the correct library prep workflow and assigns to the
     QuantStudio workflow if required based on UDFs "Prep Workflow", "Species" and "Skip genotyping for (human) sample?"

--- a/scripts/assign_workflow_seqlab_quantstudio.py
+++ b/scripts/assign_workflow_seqlab_quantstudio.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
+from egcg_core.config import cfg
+
 from EPPs.common import StepEPP, get_workflow_stage, find_newest_artifact_originating_from
 
 
 class AssignWorkflowSeqLabQuantStudio(StepEPP):
-    _use_load_config = False  # prevent the loading of the config file
+    _use_load_config = True  # prevent the loading of the config file
     """
     Assigns plates of submitted samples or FluidX derived artifacts to the correct library prep workflow and assigns to the
     QuantStudio workflow if required based on UDFs "Prep Workflow", "Species" and "Skip genotyping for (human) sample?"
@@ -38,27 +40,29 @@ class AssignWorkflowSeqLabQuantStudio(StepEPP):
                 else:
                     artifact = find_newest_artifact_originating_from(
                         self.lims,
-                        process_type="FluidX Transfer From Rack Into Plate EG 1.0 ST",
+                        process_type=cfg.query('process_type', 'fluidx_transfer'),
                         sample_name=sample.name
                     )
                     artifacts_to_route_quant.add(artifact)
 
         if artifacts_to_route_pcr_free:
-            stage = get_workflow_stage(self.lims, "TruSeq PCR-Free DNA Sample Prep", "Visual QC")
+            stage_wf_st = cfg.query('workflow_stage', 'pcr-free')
+            stage = get_workflow_stage(self.lims, stage_wf_st[0], stage_wf_st[1])
             self.lims.route_artifacts(list(artifacts_to_route_pcr_free), stage_uri=stage.uri)
 
         if artifacts_to_route_nano:
-            stage = get_workflow_stage(self.lims, "TruSeq Nano DNA Sample Prep", "Visual QC")
+            stage_wf_st= cfg.query('workflow_stage', 'nano')
+            stage = get_workflow_stage(self.lims, stage_wf_st[0], stage_wf_st[1])
             self.lims.route_artifacts(list(artifacts_to_route_nano), stage_uri=stage.uri)
 
         if artifacts_to_route_kapa:
-            stage = get_workflow_stage(self.lims, "KAPA Non-Pooling Sample Prep EG 1.0 WFDEV2",
-                                       "Sequencing Plate Picogreen EG 1.0 ST")
-
+            stage_wf_st = cfg.query('workflow_stage', 'kapa')
+            stage = get_workflow_stage(self.lims, stage_wf_st[0], stage_wf_st[1])
             self.lims.route_artifacts(list(artifacts_to_route_kapa), stage_uri=stage.uri)
 
         if artifacts_to_route_quant:
-            stage = get_workflow_stage(self.lims, "QuantStudio EG1.0", "QuantStudio Plate Preparation EG1.0")
+            stage_wf_st = cfg.query('workflow_stage', 'quantstudio')
+            stage = get_workflow_stage(self.lims, stage_wf_st[0], stage_wf_st[1])
             self.lims.route_artifacts(list(artifacts_to_route_quant), stage_uri=stage.uri)
 
 

--- a/scripts/assign_workflow_seqlab_quantstudio.py
+++ b/scripts/assign_workflow_seqlab_quantstudio.py
@@ -46,22 +46,22 @@ class AssignWorkflowSeqLabQuantStudio(StepEPP):
                     artifacts_to_route_quant.add(artifact)
 
         if artifacts_to_route_pcr_free:
-            stage_wf_st = cfg.query('workflow_stage', 'pcr-free')
+            stage_wf_st = cfg.query('workflow_stage', 'pcr-free','start')
             stage = get_workflow_stage(self.lims, stage_wf_st[0], stage_wf_st[1])
             self.lims.route_artifacts(list(artifacts_to_route_pcr_free), stage_uri=stage.uri)
 
         if artifacts_to_route_nano:
-            stage_wf_st = cfg.query('workflow_stage', 'nano')
+            stage_wf_st = cfg.query('workflow_stage', 'nano','start')
             stage = get_workflow_stage(self.lims, stage_wf_st[0], stage_wf_st[1])
             self.lims.route_artifacts(list(artifacts_to_route_nano), stage_uri=stage.uri)
 
         if artifacts_to_route_kapa:
-            stage_wf_st = cfg.query('workflow_stage', 'kapa')
+            stage_wf_st = cfg.query('workflow_stage', 'kapa','start')
             stage = get_workflow_stage(self.lims, stage_wf_st[0], stage_wf_st[1])
             self.lims.route_artifacts(list(artifacts_to_route_kapa), stage_uri=stage.uri)
 
         if artifacts_to_route_quant:
-            stage_wf_st = cfg.query('workflow_stage', 'quantstudio')
+            stage_wf_st = cfg.query('workflow_stage', 'quantstudio','start')
             stage = get_workflow_stage(self.lims, stage_wf_st[0], stage_wf_st[1])
             self.lims.route_artifacts(list(artifacts_to_route_quant), stage_uri=stage.uri)
 

--- a/tests/test_assign_to_workflow_seqlab_quantstudio.py
+++ b/tests/test_assign_to_workflow_seqlab_quantstudio.py
@@ -1,15 +1,22 @@
+from unittest.mock import Mock, patch, PropertyMock, call
+
 from scripts.assign_workflow_seqlab_quantstudio import AssignWorkflowSeqLabQuantStudio
 from tests.test_common import TestEPP, fake_artifact
-from unittest.mock import Mock, patch, PropertyMock, call
 
 
 def fake_all_outputs(unique=False, resolve=False):
     """Return a list of mocked artifacts which contain samples which contain artifacts... Simple!"""
     return (
-        Mock(id='ao1', samples=[Mock(artifact=fake_artifact('a1'), id='s1', udf={'Prep Workflow': 'TruSeq PCR-Free DNA Sample Prep', 'Species': 'Homo sapiens'})]),
-        Mock(id='ao2', samples=[Mock(artifact=fake_artifact('a2'), id='s2', udf={'Prep Workflow': 'TruSeq Nano DNA Sample Prep'})]),
-        Mock(id='ao3', samples=[Mock(artifact=fake_artifact('a3'), id='s3', udf={'Prep Workflow': 'TruSeq Nano DNA Sample Prep', 'Species': 'Homo sapiens', '2D Barcode': 'fluidX1'})]),
-        Mock(id='ao4', samples=[Mock(artifact=fake_artifact('a4'), id='s4', udf={'Prep Workflow': 'KAPA DNA Sample Prep'})])
+        Mock(id='ao1', samples=[Mock(artifact=fake_artifact('a1'), id='s1',
+                                     udf={'Prep Workflow': 'TruSeq PCR-Free DNA Sample Prep',
+                                          'Species': 'Homo sapiens'})]),
+        Mock(id='ao2', samples=[
+            Mock(artifact=fake_artifact('a2'), id='s2', udf={'Prep Workflow': 'TruSeq Nano DNA Sample Prep'})]),
+        Mock(id='ao3', samples=[Mock(artifact=fake_artifact('a3'), id='s3',
+                                     udf={'Prep Workflow': 'TruSeq Nano DNA Sample Prep', 'Species': 'Homo sapiens',
+                                          '2D Barcode': 'fluidX1'})]),
+        Mock(id='ao4',
+             samples=[Mock(artifact=fake_artifact('a4'), id='s4', udf={'Prep Workflow': 'KAPA DNA Sample Prep'})])
     )
 
 
@@ -58,6 +65,3 @@ class TestAssignWorkflowSeqLabQuantStudio(TestEPP):
             # fourth routing (quantstudio)
             route_args = self.epp.lims.route_artifacts.call_args_list[3]
             assert sorted([a.id for a in route_args[0][0]]) == ['a1', 'fx3']
-
-
-

--- a/tests/test_assign_to_workflow_seqlab_quantstudio.py
+++ b/tests/test_assign_to_workflow_seqlab_quantstudio.py
@@ -37,7 +37,7 @@ class TestAssignWorkflowSeqLabQuantStudio(TestEPP):
             pws.assert_has_calls((
                 call(self.epp.lims, 'TruSeq PCR-Free DNA Sample Prep', 'Visual QC'),
                 call(self.epp.lims, 'TruSeq Nano DNA Sample Prep', 'Visual QC'),
-                call(self.epp.lims, 'KAPA Non-Pooling Sample Prep EG 1.0 WFDEV2',
+                call(self.epp.lims, 'KAPA Non-Pooling Sample Prep EG 1.0 WF',
                      'Sequencing Plate Picogreen EG 1.0 ST'),
                 call(self.epp.lims, 'QuantStudio EG1.0', 'QuantStudio Plate Preparation EG1.0'),
 


### PR DESCRIPTION
-Script no longer hard codes the workflow and stage for assigning samples. Config file used instead.