### PR TITLE
common.py updated

### DIFF
--- a/EPPs/common.py
+++ b/EPPs/common.py
@@ -145,7 +145,7 @@ class StepEPP(app_logging.AppLogger):
         if container_type == '96 well plate':
             container_limit = 999
 
-        if container_type == 'rack 96 positions' or container_type == 'SGP rack 96 positions':
+        if container_type in ['rack 96 positions', 'SGP rack 96 positions']:
             name_template = project + 'R%02d'
             container_limit = 99
 

--- a/EPPs/common.py
+++ b/EPPs/common.py
@@ -145,7 +145,7 @@ class StepEPP(app_logging.AppLogger):
         if container_type == '96 well plate':
             container_limit = 999
 
-        if container_type == 'rack 96 positions':
+        if container_type == 'rack 96 positions' or container_type == 'SGP rack 96 positions':
             name_template = project + 'R%02d'
             container_limit = 99
 


### PR DESCRIPTION
 so find_available_container gives containers with type "SGP rack 96 positions" the same name format as containers with type "rack 96 positions"
closes #94 