### PR TITLE
Renaming gender to sex

### DIFF
--- a/scripts/populate_review_step.py
+++ b/scripts/populate_review_step.py
@@ -200,7 +200,7 @@ class PullSampleInfo(PullInfo):
         ('SR % Duplicates', 'aggregated.pc_duplicate_reads'),
         ('SR Mean Coverage', 'coverage.mean'),
         ('SR Species Found', 'aggregated.matching_species'),
-        ('SR Sex Check Match', 'aggregated.gender_match'),
+        ('SR Sex Check Match', 'aggregated.sex_match'),
         ('SR Genotyping Match', 'aggregated.genotype_match'),
         ('SR Freemix', 'sample_contamination.freemix'),
         ('SR Review Status', 'reviewed'),

--- a/tests/test_populate_review_step.py
+++ b/tests/test_populate_review_step.py
@@ -145,7 +145,7 @@ class TestPullSampleInfo(TestPopulator):
             'pc_mapped_reads': 75,
             'pc_duplicate_reads': 5,
             'mean_coverage': 30,
-            'gender_match': 'Match',
+            'sex_match': 'Match',
             'genotype_match': 'Match',
             'matching_species': ['Homo sapiens', 'Thingius thingy'],
         },


### PR DESCRIPTION
References aggregated.sex_match instead of aggregated.gender_match for EdinburghGenomics/Reporting-App#237 - closes #96 