### PR TITLE
CR1837- email_manifest_tracking_letter_customer.py minor change to script and template

### DIFF
--- a/EPPs/etc/customer_manifest.html
+++ b/EPPs/etc/customer_manifest.html
@@ -5,11 +5,15 @@
 </head>
 <body><div style="font-family:Calibri,Arial, sans-serif; font-size:12.0pt">
     <p> Dear <span style="color: #ff0000"> CUSTOMER NAME(S)</span>,</p>
-    <p>Thank you for choosing to use our sequencing service. I am the LIMS Manager at Edinburgh Genomics Clinical and I will liaise with you from sample submission up until the release of your data. I will reference this project using <b>{{ project }}</b> in the subject line of all future email correspondence.<br>
+    <p><span  style="color: #ff0000">Thank you for choosing to use our sequencing service. I am the Project Coordinator at Edinburgh Genomics Clinical and I will liaise with you from sample submission up until the release of your data. I will reference this project using <b>{{ project }}</b> in the subject line of all future email correspondence.<br>
         <br>Please find attached the following two documents:<br>
+        Thank you for choosing to use our sequencing service again. Please find attached the following two documents:<br>
+        Please find attached the following two documents for your new batch of samples:<br>
+        Please find attached the following two documents for the replacement samples:<br></span>
     <br>1) Sample Manifest &#8208; please complete all of the fields in the green columns that are relevant to your samples and return the file to EGCG-Projects@ed.ac.uk. We can only begin processing when both the manifest and samples have been received at Edinburgh Genomics.<br>
     <br>2)	Sample Submission Requirements &#8208; this document provides guidance on preparing and shipping your samples to Edinburgh Genomics Clinical.<br>
-        <br>Please note that we will require the sample(s) to have a concentration of <b>>=50ng/ul</b> at a volume of <b>>= 50 ul</b>. The sample(s) should only be shipped to us in the barcoded container(s) that we will provide. Plates must be sent frozen on dry-ice but tubes may be sent at ambient temperature.</p>
+        <br>Please note that we will require the sample(s) to have a concentration of <b>>=50ng/ul</b> at a volume of <b>>= 50 ul</b>. The sample(s) should only be shipped to us in the barcoded container(s) that we will provide. Plates must be sent frozen on dry-ice but tubes may be sent at ambient temperature.<br>
+    <br><span  style="color: #ff0000">An order has been placed for the shipment of the sample collection containers to you and these are estimated to arrive on WEEK-DAY DD-MM-YYYY/The container(s) will be placed in your Roslin mailbox by TIME DAY.</span> If you have any questions about samples submission then please don't hesitate to contact me.</p>
 <p>Kind regards,<br>
 <br><span  style="color: #ff0000">NAME<br>
     <br>SIGNATURE</span>

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ openpyxl==2.5.12
 Pillow==5.4.1
 numpy==1.15.3
 python-barcode==0.9.0
+lxml==4.3.4
 python-docx==0.8.7

--- a/scripts/email_manifest_tracking_letter_customer.py
+++ b/scripts/email_manifest_tracking_letter_customer.py
@@ -54,7 +54,6 @@ class EmailManifestLetter(SendMailEPP):
             template_name = 'customer_manifest.html'
         elif container_type_name == 'rack 96 positions':
             attachments_list.append(cfg.query('file_templates', 'requirements', 'tube'))
-            attachments_list.append(letter_filepath)
             template_name = 'customer_manifest.html'
         elif container_type_name == 'SGP rack 96 positions':
             attachments_list.append(letter_filepath)

--- a/tests/test_emails.py
+++ b/tests/test_emails.py
@@ -505,7 +505,7 @@ class TestEmailManifestTrackingLetter(TestEmailEPP):
             self.epp._run()
             mocked_send_email.assert_called_with(
                 attachments=['a_manifest-Edinburgh_Genomics_Sample_Submission_Manifest_project1.xlsx',
-                             'tube requirements', 'a_letter-Edinburgh_Genomics_Sample_Tracking_Letter_project1.docx'],
+                             'tube requirements'],
                 msg=None,
                 subject='project1: Homo sapiens WGS Sample Submission',
                 mailhost='smtp.test.me',


### PR DESCRIPTION
 - nolonger attachs tracking letter to emails for standard tube emails.

-customer_manifest.html - template text updated
-test updated correspondingly